### PR TITLE
Add application dashboard with admin panel and default icons

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+Dockerfile
+docker-compose.yml
+README.md
+Adobe Photoshop Image.19.psd
+Map.html
+Новый текстовый документ.txt
+dl
+sdf
+work

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx:alpine
+RUN rm -rf /usr/share/nginx/html/*
+COPY dashboard.html /usr/share/nginx/html/index.html
+COPY admin.html /usr/share/nginx/html/admin.html
+COPY css /usr/share/nginx/html/css
+COPY js /usr/share/nginx/html/js
+COPY images /usr/share/nginx/html/images
+COPY favicon.svg /usr/share/nginx/html/favicon.svg
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@
 - `dashboard.html` — displays service cards with icon, description, status and bookmarks.
 - `admin.html` — manage cards; data is stored in the browser's localStorage.
 - Default icons are located in `images/icons`, and `favicon.svg` is used as the site icon.
+
+## Run with Docker Compose
+
+1. Build and start the container:
+   ```bash
+   docker compose up --build
+   ```
+2. Open [http://localhost:8080](http://localhost:8080) to see the dashboard.
+   The admin panel is at [http://localhost:8080/admin.html](http://localhost:8080/admin.html).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-"# final" 
+# final
+
+## Application dashboard
+
+- `dashboard.html` — displays service cards with icon, description, status and bookmarks.
+- `admin.html` — manage cards; data is stored in the browser's localStorage.
+- Default icons are located in `images/icons`, and `favicon.svg` is used as the site icon.

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin panel</title>
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="stylesheet" href="css/bootstrap.css">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <div class="container py-4">
+    <h1 class="mb-4">Admin panel</h1>
+    <form id="service-form">
+      <input type="hidden" id="service-id">
+      <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input type="text" id="service-name" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Description</label>
+        <textarea id="service-description" class="form-control" required></textarea>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">URL</label>
+        <input type="url" id="service-url" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Icon URL (optional)</label>
+        <input type="url" id="service-icon" class="form-control">
+      </div>
+      <div id="bookmark-container" class="mb-3">
+        <label class="form-label">Bookmarks</label>
+      </div>
+      <button type="button" id="add-bookmark" class="btn btn-sm btn-outline-secondary mb-3">Add bookmark</button>
+      <div>
+        <button type="submit" class="btn btn-primary">Save</button>
+        <button type="button" id="reset-form" class="btn btn-secondary">Clear</button>
+      </div>
+    </form>
+    <hr>
+    <h2>Existing services</h2>
+    <div id="service-list"></div>
+    <a href="dashboard.html" class="btn btn-secondary mt-3">Back to dashboard</a>
+  </div>
+  <script src="js/admin.js"></script>
+</body>
+</html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Application Dashboard</title>
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="stylesheet" href="css/bootstrap.css">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <div class="container py-4">
+    <h1 class="mb-4">Application Dashboard</h1>
+    <div id="app-container" class="row"></div>
+    <a href="admin.html" class="btn btn-secondary mt-3">Admin panel</a>
+  </div>
+  <script src="js/dashboard.js"></script>
+</body>
+</html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#F97300"/>
+  <text x="32" y="40" font-size="36" text-anchor="middle" fill="#fff" font-family="Arial, Helvetica, sans-serif">D</text>
+</svg>

--- a/images/icons/default1.svg
+++ b/images/icons/default1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#d1d5db"/>
+  <circle cx="32" cy="24" r="12" fill="#6b7280"/>
+  <rect x="16" y="40" width="32" height="16" fill="#6b7280"/>
+</svg>

--- a/images/icons/default2.svg
+++ b/images/icons/default2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#d1d5db"/>
+  <path d="M16 44L32 16l16 28H16z" fill="#6b7280"/>
+</svg>

--- a/images/icons/default3.svg
+++ b/images/icons/default3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#d1d5db"/>
+  <circle cx="32" cy="32" r="20" fill="#6b7280"/>
+  <circle cx="32" cy="32" r="10" fill="#d1d5db"/>
+</svg>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,87 @@
+function loadServices() {
+  return JSON.parse(localStorage.getItem('services') || '[]');
+}
+
+function saveServices(services) {
+  localStorage.setItem('services', JSON.stringify(services));
+}
+
+function renderList() {
+  const services = loadServices();
+  const list = document.getElementById('service-list');
+  list.innerHTML = '';
+  services.forEach(svc => {
+    const div = document.createElement('div');
+    div.className = 'border rounded p-2 mb-2';
+    div.innerHTML = `<strong>${svc.name}</strong> - ${svc.description}
+    <div class="mt-2">
+      <button class="btn btn-sm btn-primary me-2" data-edit="${svc.id}">Edit</button>
+      <button class="btn btn-sm btn-danger" data-delete="${svc.id}">Delete</button>
+    </div>`;
+    list.appendChild(div);
+  });
+}
+
+function addBookmarkRow(title = '', url = '') {
+  const container = document.getElementById('bookmark-container');
+  const row = document.createElement('div');
+  row.className = 'input-group mb-1';
+  row.innerHTML = `
+    <input type="text" class="form-control" placeholder="Title" value="${title}">
+    <input type="url" class="form-control" placeholder="URL" value="${url}">
+    <button class="btn btn-outline-danger" type="button">&times;</button>`;
+  row.querySelector('button').addEventListener('click', () => row.remove());
+  container.appendChild(row);
+}
+
+document.getElementById('add-bookmark').addEventListener('click', () => addBookmarkRow());
+
+document.getElementById('reset-form').addEventListener('click', () => {
+  document.getElementById('service-form').reset();
+  document.getElementById('service-id').value = '';
+  document.getElementById('bookmark-container').innerHTML = '<label class="form-label">Bookmarks</label>';
+});
+
+document.getElementById('service-form').addEventListener('submit', e => {
+  e.preventDefault();
+  const id = document.getElementById('service-id').value || Date.now().toString();
+  const name = document.getElementById('service-name').value;
+  const description = document.getElementById('service-description').value;
+  const url = document.getElementById('service-url').value;
+  const icon = document.getElementById('service-icon').value;
+  const bookmarks = Array.from(document.querySelectorAll('#bookmark-container .input-group')).map(group => {
+    const inputs = group.querySelectorAll('input');
+    return { title: inputs[0].value, url: inputs[1].value };
+  }).filter(b => b.title && b.url);
+  let services = loadServices();
+  const index = services.findIndex(s => s.id === id);
+  const service = { id, name, description, url, icon, bookmarks };
+  if (index >= 0) services[index] = service; else services.push(service);
+  saveServices(services);
+  renderList();
+  document.getElementById('reset-form').click();
+});
+
+document.getElementById('service-list').addEventListener('click', e => {
+  if (e.target.dataset.edit) {
+    const svc = loadServices().find(s => s.id === e.target.dataset.edit);
+    if (svc) {
+      document.getElementById('service-id').value = svc.id;
+      document.getElementById('service-name').value = svc.name;
+      document.getElementById('service-description').value = svc.description;
+      document.getElementById('service-url').value = svc.url;
+      document.getElementById('service-icon').value = svc.icon || '';
+      const container = document.getElementById('bookmark-container');
+      container.innerHTML = '<label class="form-label">Bookmarks</label>';
+      (svc.bookmarks || []).forEach(b => addBookmarkRow(b.title, b.url));
+      window.scrollTo(0, 0);
+    }
+  }
+  if (e.target.dataset.delete) {
+    let services = loadServices().filter(s => s.id !== e.target.dataset.delete);
+    saveServices(services);
+    renderList();
+  }
+});
+
+document.addEventListener('DOMContentLoaded', renderList);

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,0 +1,40 @@
+const defaultIcons = [
+  'images/icons/default1.svg',
+  'images/icons/default2.svg',
+  'images/icons/default3.svg'
+];
+
+function loadServices() {
+  const services = JSON.parse(localStorage.getItem('services') || '[]');
+  const container = document.getElementById('app-container');
+  container.innerHTML = '';
+  services.forEach((svc, i) => {
+    const card = document.createElement('div');
+    card.className = 'col-md-4';
+    card.innerHTML = `
+      <div class="card mb-4">
+        <img src="${svc.icon || defaultIcons[i % defaultIcons.length]}" class="card-img-top" alt="${svc.name}">
+        <div class="card-body">
+          <h5 class="card-title">${svc.name}</h5>
+          <p class="card-text">${svc.description}</p>
+          <p class="card-text"><strong>Status:</strong> <span data-status="${i}">Checking...</span></p>
+          <div>${(svc.bookmarks||[]).map(b=>`<a href="${b.url}" class="badge bg-primary me-1" target="_blank">${b.title}</a>`).join('')}</div>
+        </div>
+      </div>`;
+    container.appendChild(card);
+    checkStatus(svc.url, i);
+  });
+}
+
+function checkStatus(url, i) {
+  fetch(url, {method:'HEAD'})
+    .then(r => setStatus(i, r.ok ? '🟢 Online' : '🔴 Offline'))
+    .catch(() => setStatus(i, '🔴 Offline'));
+}
+
+function setStatus(i, text) {
+  const el = document.querySelector(`[data-status="${i}"]`);
+  if (el) el.textContent = text;
+}
+
+document.addEventListener('DOMContentLoaded', loadServices);


### PR DESCRIPTION
## Summary
- Add `dashboard.html` to display service cards with icons, descriptions, online status, and bookmarks
- Add `admin.html` for managing cards stored in browser localStorage
- Include site favicon and default SVG icons for services

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8db9a2648322859a7377ac484ca6