### PR TITLE
Add additional default icons and update site icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 - `dashboard.html` — displays service cards with icon, description, status and bookmarks.
 - `admin.html` — manage cards; data is stored in the browser's localStorage.
-- Default icons are located in `images/icons`, and `favicon.svg` is used as the site icon.
+- Default icons are located in `images/icons`. The dashboard cycles through six built-in SVG images
+  (`default*.svg` and `alt*.svg`) when no custom icon is provided. `favicon.svg` serves as the
+  site icon.
 
 ## Run with Docker Compose
 

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" ry="8" fill="#F97300"/>
-  <text x="32" y="40" font-size="36" text-anchor="middle" fill="#fff" font-family="Arial, Helvetica, sans-serif">D</text>
+  <rect width="64" height="64" rx="8" ry="8" fill="#2563eb"/>
+  <text x="32" y="40" font-size="36" text-anchor="middle" fill="#fff" font-family="Arial, Helvetica, sans-serif">A</text>
 </svg>

--- a/images/icons/alt1.svg
+++ b/images/icons/alt1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#bfdbfe"/>
+  <circle cx="32" cy="32" r="16" fill="#3b82f6"/>
+</svg>

--- a/images/icons/alt2.svg
+++ b/images/icons/alt2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#bbf7d0"/>
+  <path d="M32 16L48 48H16z" fill="#10b981"/>
+</svg>

--- a/images/icons/alt3.svg
+++ b/images/icons/alt3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#e9d5ff"/>
+  <rect x="20" y="20" width="24" height="24" fill="#a855f7"/>
+</svg>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,7 +1,10 @@
 const defaultIcons = [
   'images/icons/default1.svg',
   'images/icons/default2.svg',
-  'images/icons/default3.svg'
+  'images/icons/default3.svg',
+  'images/icons/alt1.svg',
+  'images/icons/alt2.svg',
+  'images/icons/alt3.svg'
 ];
 
 function loadServices() {


### PR DESCRIPTION
## Summary
- Expand default icon list with colorful SVG alternatives
- Refresh favicon design
- Document new icon sets in README

## Testing
- `node --check js/dashboard.js`
- `node --check js/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba926c591c83228f5e09bd72b3253e